### PR TITLE
don't depend on meta-package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
 
   <url>http://plasmodic.github.io/ecto_ros</url>
 
-  <build_depend>common_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <build_depend>ecto</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>


### PR DESCRIPTION
Only sensor_msgs really is needed in this module.
This is related to #1 . Please fix it before the release as well.
