### PR TITLE
Remove usage of SYSTEM in include_directories

### DIFF
--- a/cmake/pubsub_gen_wrap.cmake
+++ b/cmake/pubsub_gen_wrap.cmake
@@ -85,7 +85,7 @@ macro(pubsub_gen_wrap ROS_PACKAGE)
     message(STATUS "+ ${ROS_PACKAGE}: ${len} message types")
   endif()
 
-  include_directories(SYSTEM ${ecto_INCLUDE_DIRS}
+  include_directories(${ecto_INCLUDE_DIRS}
                              ${ecto_ros_INCLUDE_DIRS}
                              ${roscpp_INCLUDE_DIRS}
                              ${CMAKE_BINARY_DIR}/gen/cpp/${ROS_PACKAGE}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(OpenCV REQUIRED)
 find_package(Eigen REQUIRED)
 
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS}
+include_directories(${catkin_INCLUDE_DIRS}
                     ${Eigen_INCLUDE_DIRS}
                     ${ROS_INCLUDE_DIRS}
 )


### PR DESCRIPTION
SYSTEM should be used sparingly and causes some things to go awry in ros workspaces.

See dirk's comments at the end of https://github.com/ros/catkin/issues/428.
