### PR TITLE
Backdoor for blocking subscribers

### DIFF
--- a/include/ecto_ros/wrap_sub.hpp
+++ b/include/ecto_ros/wrap_sub.hpp
@@ -112,13 +112,16 @@ namespace ecto_ros
     process(const ecto::tendrils& in, const ecto::tendrils& out)
     {
       sub_thread_.join();
-      //condition variable idiom, blocks until the data has
-      //been filled by ros.
+      //condition variable idiom, blocks until the data has been filled by ros.
+      unsigned int counter = 0;
       boost::unique_lock<boost::mutex> lock(mut_);
       while (queue_.empty())
       {
         boost::this_thread::interruption_point();
         cond_.timed_wait(lock,boost::posix_time::millisec(5));
+        if ( counter++ > 40 )  {
+          return ecto::DO_OVER; // give the scheduler a chance to manage (e.g. abort)
+        }
       }
       *out_ = queue_.front();
       queue_.pop_front();


### PR DESCRIPTION
This lets the scheduler avoid getting permanently blocked when processing a subscriber cell and allowing it to make a decision. This is mostly for use when closing down to allow the scheduler to abort execution of a plasm.

See #250, in particular [here](https://github.com/plasmodic/ecto/pull/250/files#diff-8102ff9c980072a684d1f6fbc7b01e57R206) where an interruption decision is made.

The timeout for DO_OVER here is hardcode (40x5ms). I guess this could be a parameter, but can't think of a use case where this parameter is actually important to the user.
