### PR TITLE
Exposing number of subscribers

### DIFF
--- a/include/ecto_ros/wrap_pub.hpp
+++ b/include/ecto_ros/wrap_pub.hpp
@@ -96,7 +96,8 @@ namespace ecto_ros
     {
       int num_subscribers = pub_.getNumSubscribers();
       *has_subscribers_ = (num_subscribers != 0) ? true : false;
-      if(*in_ && (num_subscribers != 0)) {
+      // lazy publishing if appropriate conditions are met
+      if(*in_ && (*has_subscribers_ || latched_)) { 
         pub_.publish(**in_);
       }
       return ecto::OK;


### PR DESCRIPTION
- Use it to ensure publishing is _lazy_ so long as it is not latched
- Provide an output to other cells so they can avoid work before passing results to this publisher.
