### PR TITLE
[Image2Mat] lazy conversion depending on presence of input.

### DIFF
--- a/src/cv_bridge.cpp
+++ b/src/cv_bridge.cpp
@@ -277,14 +277,21 @@ namespace ecto_ros
     {
       ImageConstPtr image = *image_msg_;
       cv::Mat mat;
-      // Construct matrix pointing to source data
-      int source_type = getCvType(image->encoding);
-      cv::Mat temp((int) image->height, (int) image->width, source_type, const_cast<uint8_t*>(&image->data[0]),
-                   (size_t) image->step);
-      if (swap_rgb_)
-        cv::cvtColor(temp, mat, CV_BGR2RGB);
-      else
-        temp.copyTo(mat);
+      // lazy conversion - only do something if there is an established incoming image
+      //   i.e. check there is an image input, and that there has at least been some effort
+      //   to initialise it with something by checking the encoding field.
+      // If nothing interesting coming in, just pass out an empty cv::Mat object.
+      //   i.e. let the consumer decide how he wants to handle it.
+      if ( image && !image->encoding.empty() ) {
+        // Construct matrix pointing to source data
+        int source_type = getCvType(image->encoding);
+        cv::Mat temp((int) image->height, (int) image->width, source_type, const_cast<uint8_t*>(&image->data[0]),
+                     (size_t) image->step);
+        if (swap_rgb_)
+          cv::cvtColor(temp, mat, CV_BGR2RGB);
+        else
+          temp.copyTo(mat);
+      }
       mat.copyTo(*mat_);
       return ecto::OK;
     }


### PR DESCRIPTION
This lets the consumer of the cv mat decide how he wants to handle
the situation when there is nothing coming through rather than
the current situation where it will crash if the input shared
ptr is null, or throw an exception (about unknown encoding)
and terminate if it is an empty image message.